### PR TITLE
Remove isSavedPost endpoint

### DIFF
--- a/src/api/controllers/PostController.ts
+++ b/src/api/controllers/PostController.ts
@@ -84,9 +84,4 @@ export class PostController {
   async unsavePost(@CurrentUser() user: UserModel, @Params() params: UuidParam): Promise<GetPostResponse> {
     return { post: await this.postService.unsavePost(user, params) };
   }
-
-  @Get('isSaved/postId/:id/')
-  async isSavedPost(@CurrentUser() user: UserModel, @Params() params: UuidParam): Promise<IsSavedPostResponse> {
-    return { isSaved: await this.postService.isSavedPost(user, params) };
-  }
 }

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -37,15 +37,6 @@ export class UserRepository extends AbstractRepository<UserModel> {
     return post;
   }
 
-  public async isSavedPost(user: UserModel, post: PostModel): Promise<boolean> {
-    for (const savedPost of user.saved) {
-      if (savedPost.id === post.id) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public async getSavedPostsByUserId(id: Uuid): Promise<UserModel | undefined> {
     return await this.repository
       .createQueryBuilder("user")

--- a/src/services/PostService.ts
+++ b/src/services/PostService.ts
@@ -7,7 +7,7 @@ import { UuidParam } from '../api/validators/GenericRequests';
 import { PostModel } from '../models/PostModel';
 import { UserModel } from '../models/UserModel';
 import Repositories, { TransactionsManager } from '../repositories';
-import { CreatePostRequest, FilterPostsRequest, GetSearchedPostsRequest, Post } from '../types';
+import { CreatePostRequest, FilterPostsRequest, GetSearchedPostsRequest } from '../types';
 import { uploadImage } from '../utils/Requests';
 
 @Service()
@@ -156,19 +156,6 @@ export class PostService {
       if (!post) throw new NotFoundError('Post not found!');
       const userRepository = Repositories.user(transactionalEntityManager);
       return await userRepository.unsavePost(user, post);
-    });
-  }
-
-  public async isSavedPost(user: UserModel, params: UuidParam): Promise<boolean> {
-    return this.transactions.readOnly(async (transactionalEntityManager) => {
-      const postRepository = Repositories.post(transactionalEntityManager);
-      const post = await postRepository.getPostById(params.id);
-      if (!post) throw new NotFoundError('Post not found!');
-      const userRepository = Repositories.user(transactionalEntityManager);
-      const newUser = await userRepository.getSavedPostsByUserId(user.id);
-      if (!newUser) throw new NotFoundError('User not found!');
-      const isSaved = (p: PostModel) => p.id == post.id;
-      return newUser.saved.some(isSaved);
     });
   }
 }

--- a/src/services/PostService.ts
+++ b/src/services/PostService.ts
@@ -7,7 +7,7 @@ import { UuidParam } from '../api/validators/GenericRequests';
 import { PostModel } from '../models/PostModel';
 import { UserModel } from '../models/UserModel';
 import Repositories, { TransactionsManager } from '../repositories';
-import { CreatePostRequest, FilterPostsRequest, GetSearchedPostsRequest } from '../types';
+import { CreatePostRequest, FilterPostsRequest, GetSearchedPostsRequest, Post } from '../types';
 import { uploadImage } from '../utils/Requests';
 
 @Service()
@@ -165,7 +165,10 @@ export class PostService {
       const post = await postRepository.getPostById(params.id);
       if (!post) throw new NotFoundError('Post not found!');
       const userRepository = Repositories.user(transactionalEntityManager);
-      return await userRepository.isSavedPost(user, post);
+      const newUser = await userRepository.getSavedPostsByUserId(user.id);
+      if (!newUser) throw new NotFoundError('User not found!');
+      const isSaved = (p: PostModel) => p.id == post.id;
+      return newUser.saved.some(isSaved);
     });
   }
 }

--- a/src/tests/PostTest.test.ts
+++ b/src/tests/PostTest.test.ts
@@ -315,14 +315,10 @@ describe('post tests', () => {
       .write();
 
     let postsResponse = await postController.getSavedPostsByUserId(user);
-    let isSavedResponse = await postController.isSavedPost(user, { id: post.id })
-    expect(isSavedResponse.isSaved).toBe(false)
     expect(postsResponse).not.toBeUndefined();
     expect(postsResponse.posts).toEqual([]);
 
     await postController.savePost(user, uuidParam);
-    isSavedResponse = await postController.isSavedPost(user, { id: post.id })
-    expect(isSavedResponse.isSaved).toBe(true)
     postsResponse = await postController.getSavedPostsByUserId(user);
     expect(postsResponse).not.toBeUndefined();
     postsResponse.posts[0].price = Number(postsResponse.posts[0].price);
@@ -330,8 +326,6 @@ describe('post tests', () => {
     expect(postsResponse.posts).toEqual([expectedPost]);
 
     await postController.unsavePost(user, uuidParam);
-    isSavedResponse = await postController.isSavedPost(user, { id: post.id })
-    expect(isSavedResponse.isSaved).toBe(false)
     postsResponse = await postController.getSavedPostsByUserId(user);
     expect(postsResponse.posts).toEqual([]);
   });

--- a/src/tests/PostTest.test.ts
+++ b/src/tests/PostTest.test.ts
@@ -311,14 +311,18 @@ describe('post tests', () => {
 
     await new DataFactory()
       .createPosts(post)
-      .createUsers(post.user)
+      .createUsers(user)
       .write();
 
     let postsResponse = await postController.getSavedPostsByUserId(user);
+    let isSavedResponse = await postController.isSavedPost(user, { id: post.id })
+    expect(isSavedResponse.isSaved).toBe(false)
     expect(postsResponse).not.toBeUndefined();
     expect(postsResponse.posts).toEqual([]);
 
     await postController.savePost(user, uuidParam);
+    isSavedResponse = await postController.isSavedPost(user, { id: post.id })
+    expect(isSavedResponse.isSaved).toBe(true)
     postsResponse = await postController.getSavedPostsByUserId(user);
     expect(postsResponse).not.toBeUndefined();
     postsResponse.posts[0].price = Number(postsResponse.posts[0].price);
@@ -326,6 +330,8 @@ describe('post tests', () => {
     expect(postsResponse.posts).toEqual([expectedPost]);
 
     await postController.unsavePost(user, uuidParam);
+    isSavedResponse = await postController.isSavedPost(user, { id: post.id })
+    expect(isSavedResponse.isSaved).toBe(false)
     postsResponse = await postController.getSavedPostsByUserId(user);
     expect(postsResponse.posts).toEqual([]);
   });


### PR DESCRIPTION
## Overview

Fix bug where if a user has no saved posts it fails by trying to iterate through an uniterable object
Did this by deleting the endpoint 


## Changes Made

- Deleted unnecessary endpoint


## Test Coverage

-Passed testing suite


## Related PRs or Issues

- Closes #50 