### PR TITLE
Protect getAllUsers endpoint

### DIFF
--- a/src/api/controllers/UserController.ts
+++ b/src/api/controllers/UserController.ts
@@ -14,8 +14,8 @@ export class UserController {
   }
 
   @Get()
-  async getUsers(): Promise<GetUsersResponse> {
-    const users = await this.userService.getAllUsers();
+  async getUsers(@CurrentUser() user: UserModel): Promise<GetUsersResponse> {
+    const users = await this.userService.getAllUsers(user);
     return { users: users.map((user) => user.getUserProfile()) };
   }
 

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -17,7 +17,8 @@ export class UserService {
     this.transactions = new TransactionsManager(entityManager);
   }
 
-  public async getAllUsers(): Promise<UserModel[]> {
+  public async getAllUsers(user: UserModel): Promise<UserModel[]> {
+    if (!user.admin) throw new UnauthorizedError('User does not have permission to get all users')
     return this.transactions.readOnly(async (transactionalEntityManager) => {
       const userRepository = Repositories.user(transactionalEntityManager);
       return userRepository.getAllUsers();

--- a/src/tests/UserTest.test.ts
+++ b/src/tests/UserTest.test.ts
@@ -44,31 +44,35 @@ afterAll(async () => {
 
 describe('user tests', () => {
   test('get all users - no users', async () => {
-    const getUsersResponse = await userController.getUsers();
+    const user = UserFactory.fake();
+    user.admin = true;
+    const getUsersResponse = await userController.getUsers(user);
 
     expect(getUsersResponse.users).toHaveLength(0);
   });
 
   test('get all users - one user', async () => {
     const user = UserFactory.fake();
+    user.admin = true
 
     await new DataFactory()
       .createUsers(user)
       .write();
 
-    const getUsersResponse = await userController.getUsers();
+    const getUsersResponse = await userController.getUsers(user);
 
     expect(getUsersResponse.users).toHaveLength(1);
   });
 
   test('get all users - multiple users', async () => {
     const [user1, user2] = UserFactory.create(2);
+    user1.admin = true
 
     await new DataFactory()
       .createUsers(user1, user2)
       .write();
 
-    const getUsersResponse = await userController.getUsers();
+    const getUsersResponse = await userController.getUsers(user1);
 
     expect(getUsersResponse.users).toHaveLength(2);
   });


### PR DESCRIPTION
## Overview

Protect  getAllUsers endpoint so that only admin users can use it


## Changes Made

- Added need for authentication token
- Implemented admin logic


## Test Coverage

- Adapted tests for getAllUsers
- Passed test suite