### PR TITLE
Add isSaved to getPostById

### DIFF
--- a/src/api/controllers/PostController.ts
+++ b/src/api/controllers/PostController.ts
@@ -8,7 +8,6 @@ import {
   GetPostResponse,
   GetPostsResponse,
   GetSearchedPostsRequest,
-  IsSavedPostResponse,
 } from '../../types';
 import { UuidParam } from '../validators/GenericRequests';
 
@@ -26,8 +25,8 @@ export class PostController {
   }
 
   @Get('id/:id/')
-  async getPostById(@Params() params: UuidParam): Promise<GetPostResponse> {
-    return { post: await this.postService.getPostById(params) };
+  async getPostById(@CurrentUser() user: UserModel, @Params() params: UuidParam): Promise<GetPostResponse> {
+    return { post: await this.postService.getPostById(user, params) };
   }
 
   @Get('userId/:id/')
@@ -83,10 +82,5 @@ export class PostController {
   @Get('unsave/postId/:id/')
   async unsavePost(@CurrentUser() user: UserModel, @Params() params: UuidParam): Promise<GetPostResponse> {
     return { post: await this.postService.unsavePost(user, params) };
-  }
-
-  @Get('isSaved/postId/:id/')
-  async isSavedPost(@CurrentUser() user: UserModel, @Params() params: UuidParam): Promise<IsSavedPostResponse> {
-    return { isSaved: await this.postService.isSavedPost(user, params) };
   }
 }

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -37,13 +37,13 @@ export class UserRepository extends AbstractRepository<UserModel> {
     return post;
   }
 
-  public async isSavedPost(user: UserModel, post: PostModel): Promise<boolean> {
-    for (const savedPost of user.saved) {
-      if (savedPost.id === post.id) {
-        return true;
-      }
-    }
-    return false;
+  public async isSavedPost(userId: Uuid, id: Uuid): Promise<boolean> {
+    const postIsSaved = await this.repository
+      .createQueryBuilder("user")
+      .where("user.id = :userId", { userId })
+      .innerJoinAndSelect("user.saved", "post", "post.id = :id", { id })
+      .getOne();
+    return postIsSaved != undefined;
   }
 
   public async getSavedPostsByUserId(id: Uuid): Promise<UserModel | undefined> {

--- a/src/tests/PostTest.test.ts
+++ b/src/tests/PostTest.test.ts
@@ -1,4 +1,5 @@
 import { PostController } from 'src/api/controllers/PostController';
+import { Post, PostWithIsSaved } from 'src/types';
 import { Connection } from 'typeorm';
 
 import { UuidParam } from '../api/validators/GenericRequests';
@@ -86,11 +87,13 @@ describe('post tests', () => {
       .write();
 
     expectedPost.user = post.user;
+    let newlyExpectedPost = expectedPost as unknown as PostWithIsSaved
+    newlyExpectedPost.isSaved = false
 
-    const getPostResponse = await postController.getPostById(uuidParam);
+    const getPostResponse = await postController.getPostById(post.user, uuidParam);
     getPostResponse.post.price = Number(getPostResponse.post.price);
     expectedPost.created = getPostResponse.post.created;
-    expect(getPostResponse.post).toEqual(expectedPost);
+    expect(getPostResponse.post).toEqual(newlyExpectedPost);
   });
 
   test('get post by user id', async () => {

--- a/src/tests/PostTest.test.ts
+++ b/src/tests/PostTest.test.ts
@@ -77,7 +77,7 @@ describe('post tests', () => {
     expect(getPostsResponse.posts).toHaveLength(2);
   });
 
-  test('get post by id', async () => {
+  test('get post by id - post is not saved', async () => {
     const post = PostFactory.fakeTemplate();
     post.user = UserFactory.fakeTemplate();
 
@@ -92,7 +92,29 @@ describe('post tests', () => {
 
     const getPostResponse = await postController.getPostById(post.user, uuidParam);
     getPostResponse.post.price = Number(getPostResponse.post.price);
-    expectedPost.created = getPostResponse.post.created;
+    newlyExpectedPost.created = getPostResponse.post.created;
+    expect(getPostResponse.post).toEqual(newlyExpectedPost);
+  });
+
+  test('get post by id - post is saved', async () => {
+    const post = PostFactory.fakeTemplate();
+    const user = UserFactory.fakeTemplate();
+    post.user = UserFactory.fake()
+    user.saved = [];
+
+    await new DataFactory()
+      .createPosts(post)
+      .createUsers(user, post.user)
+      .write();
+
+    expectedPost.user = post.user;
+    let newlyExpectedPost = expectedPost as unknown as PostWithIsSaved
+    newlyExpectedPost.isSaved = true
+
+    await postController.savePost(user, uuidParam);
+    const getPostResponse = await postController.getPostById(user, uuidParam);
+    getPostResponse.post.price = Number(getPostResponse.post.price);
+    newlyExpectedPost.created = getPostResponse.post.created;
     expect(getPostResponse.post).toEqual(newlyExpectedPost);
   });
 

--- a/src/types/ApiResponses.ts
+++ b/src/types/ApiResponses.ts
@@ -58,16 +58,16 @@ export interface Post {
     matched: Request[],
 }
 
+export interface PostWithIsSaved extends Post {
+    isSaved: boolean;
+}
+
 export interface GetPostsResponse {
     posts: Post[];
 }
 
 export interface GetPostResponse {
-    post: Post;
-}
-
-export interface IsSavedPostResponse {
-    isSaved: boolean;
+    post: Post | PostWithIsSaved;
 }
 
 // FEEDBACK


### PR DESCRIPTION
## Overview

Add isSaved to getPostById so frontend always knows if a post is saved by a user without needing two routes



## Changes Made

- getPostById is now a protected endpoint
- It returns if the post is saved as a field of the response body



## Test Coverage

Added to test suite and it all passed