### PR TITLE
Add price filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "body-parser": "^1.19.1",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.13.2",
+    "class-validator": "^0.14.0",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.2",

--- a/src/api/controllers/PostController.ts
+++ b/src/api/controllers/PostController.ts
@@ -5,6 +5,7 @@ import { PostService } from '../../services/PostService';
 import {
   CreatePostRequest,
   FilterPostsRequest,
+  FilterPostsByPriceRequest,
   GetPostResponse,
   GetPostsResponse,
   GetSearchedPostsRequest,
@@ -53,6 +54,11 @@ export class PostController {
   @Post('filter/')
   async filterPosts(@Body() filterPostsRequest: FilterPostsRequest): Promise<GetPostsResponse> {
     return { posts: await this.postService.filterPosts(filterPostsRequest) };
+  }
+
+  @Post('filterByPrice/')
+  async filterPostsByPrice(@Body() filterPostsByPriceRequest: FilterPostsByPriceRequest): Promise<GetPostsResponse> {
+    return { posts: await this.postService.filterPostsByPrice(filterPostsByPriceRequest) };
   }
 
   @Get('archive/')

--- a/src/repositories/PostRepository.ts
+++ b/src/repositories/PostRepository.ts
@@ -1,3 +1,4 @@
+import internal from 'stream';
 import { AbstractRepository, EntityRepository } from 'typeorm';
 
 import { PostModel } from '../models/PostModel';
@@ -86,6 +87,16 @@ export class PostRepository extends AbstractRepository<PostModel> {
       .createQueryBuilder("post")
       .leftJoinAndSelect("post.user", "user")
       .where(":category = ANY (post.categories)", { category: category })
+      .andWhere("post.archive = false")
+      .getMany();
+  }
+
+  public async filterPostsByPrice(lowerBound: number, upperBound: number): Promise<PostModel[]> {
+    return await this.repository
+      .createQueryBuilder("post")
+      .leftJoinAndSelect("post.user", "user")
+      .where("post.price >= :lowerBound", {lowerBound: lowerBound})
+      .andWhere("post.price <= :upperBound", {upperBound: upperBound})
       .andWhere("post.archive = false")
       .getMany();
   }

--- a/src/repositories/PostRepository.ts
+++ b/src/repositories/PostRepository.ts
@@ -1,4 +1,3 @@
-import internal from 'stream';
 import { AbstractRepository, EntityRepository } from 'typeorm';
 
 import { PostModel } from '../models/PostModel';

--- a/src/services/PostService.ts
+++ b/src/services/PostService.ts
@@ -7,7 +7,7 @@ import { UuidParam } from '../api/validators/GenericRequests';
 import { PostModel } from '../models/PostModel';
 import { UserModel } from '../models/UserModel';
 import Repositories, { TransactionsManager } from '../repositories';
-import { CreatePostRequest, FilterPostsRequest, GetSearchedPostsRequest } from '../types';
+import { CreatePostRequest, FilterPostsRequest, FilterPostsByPriceRequest, GetSearchedPostsRequest } from '../types';
 import { uploadImage } from '../utils/Requests';
 
 @Service()
@@ -110,6 +110,14 @@ export class PostService {
       const posts = await postRepository.filterPosts(filterPostsRequest.category);
       return posts;
     });
+  }
+
+  public async filterPostsByPrice(filterPostsByPriceRequest: FilterPostsByPriceRequest): Promise<PostModel[]> {
+    return this.transactions.readOnly(async (transactionalEntityManager) => {
+      const postRepository = Repositories.post(transactionalEntityManager);
+      const posts = await postRepository.filterPostsByPrice(filterPostsByPriceRequest.lowerBound, filterPostsByPriceRequest.upperBound)
+      return posts;
+    })
   }
 
   public async getArchivedPosts(): Promise<PostModel[]> {

--- a/src/tests/PostTest.test.ts
+++ b/src/tests/PostTest.test.ts
@@ -1,3 +1,4 @@
+import { Controller } from 'routing-controllers';
 import { PostController } from 'src/api/controllers/PostController';
 import { Connection } from 'typeorm';
 
@@ -264,7 +265,7 @@ describe('post tests', () => {
     expect(getPostsResponse.posts).toEqual([]);
   });
 
-  test('filter posts', async () => {
+  test('filter posts by category', async () => {
     const post = PostFactory.fakeTemplate();
     post.user = UserFactory.fakeTemplate();
 
@@ -302,6 +303,60 @@ describe('post tests', () => {
     getPostsResponse = await postController.filterPosts(filter);
 
     expect(getPostsResponse.posts).toEqual([]);
+  });
+
+  test('filter posts by price', async () => {
+    const post = PostFactory.fakeTemplate();
+    post.user = UserFactory.fakeTemplate();
+
+    await new DataFactory()
+      .createPosts(post)
+      .createUsers(post.user)
+      .write();
+
+    expectedPost.user = post.user;
+
+    let filter = {
+      lowerBound: 1.0,
+      upperBound: 1000.0,
+    };
+
+    let getPostsResponse = await postController.filterPostsByPrice(filter);
+    getPostsResponse.posts[0].price = Number(getPostsResponse.posts[0].price);
+    expectedPost.created = getPostsResponse.posts[0].created;
+
+    expect(getPostsResponse.posts).toEqual([expectedPost]);
+
+    filter = {
+      lowerBound: 500.15,
+      upperBound: 1000.0,
+    };
+
+    getPostsResponse = await postController.filterPostsByPrice(filter);
+    getPostsResponse.posts[0].price = Number(getPostsResponse.posts[0].price);
+    expectedPost.created = getPostsResponse.posts[0].created;
+
+    expect(getPostsResponse.posts).toEqual([expectedPost]);
+
+    filter = {
+      lowerBound: 1.0,
+      upperBound: 500.15,
+    };
+
+    getPostsResponse = await postController.filterPostsByPrice(filter);
+    getPostsResponse.posts[0].price = Number(getPostsResponse.posts[0].price);
+    expectedPost.created = getPostsResponse.posts[0].created;
+
+    expect(getPostsResponse.posts).toEqual([expectedPost]);
+
+    filter = {
+      lowerBound: 1.0,
+      upperBound: 2.0,
+    };
+
+    getPostsResponse = await postController.filterPostsByPrice(filter);
+
+    expect(getPostsResponse.posts).toEqual([])
   });
 
   test('save/unsave posts', async () => {

--- a/src/tests/PostTest.test.ts
+++ b/src/tests/PostTest.test.ts
@@ -1,4 +1,3 @@
-import { Controller } from 'routing-controllers';
 import { PostController } from 'src/api/controllers/PostController';
 import { Connection } from 'typeorm';
 
@@ -305,9 +304,9 @@ describe('post tests', () => {
     expect(getPostsResponse.posts).toEqual([]);
   });
 
-  test('filter posts by price', async () => {
+  test('filter posts by price, where price is strictly within price range', async () => {
     const post = PostFactory.fakeTemplate();
-    post.user = UserFactory.fakeTemplate();
+    post.user = UserFactory.fake();
 
     await new DataFactory()
       .createPosts(post)
@@ -322,39 +321,75 @@ describe('post tests', () => {
     };
 
     let getPostsResponse = await postController.filterPostsByPrice(filter);
+    console.log(getPostsResponse)
     getPostsResponse.posts[0].price = Number(getPostsResponse.posts[0].price);
     expectedPost.created = getPostsResponse.posts[0].created;
 
     expect(getPostsResponse.posts).toEqual([expectedPost]);
+  });
 
-    filter = {
+  test('filter posts by price, where price is lower bound', async () => {
+    const post = PostFactory.fakeTemplate();
+    post.user = UserFactory.fake();
+    const user = UserFactory.fakeTemplate();
+
+    await new DataFactory()
+      .createPosts(post)
+      .createUsers(post.user)
+      .write();
+
+    expectedPost.user = post.user;
+    let filter = {
       lowerBound: 500.15,
       upperBound: 1000.0,
     };
 
-    getPostsResponse = await postController.filterPostsByPrice(filter);
+    let getPostsResponse = await postController.filterPostsByPrice(filter);
+    console.log(getPostsResponse)
     getPostsResponse.posts[0].price = Number(getPostsResponse.posts[0].price);
     expectedPost.created = getPostsResponse.posts[0].created;
 
     expect(getPostsResponse.posts).toEqual([expectedPost]);
+  });
 
-    filter = {
+  test('filter posts by price, where price is upper bound', async () => {
+    const post = PostFactory.fakeTemplate();
+    post.user = UserFactory.fake();
+
+    await new DataFactory()
+      .createPosts(post)
+      .createUsers(post.user)
+      .write();
+
+    expectedPost.user = post.user;
+    let filter = {
       lowerBound: 1.0,
       upperBound: 500.15,
     };
 
-    getPostsResponse = await postController.filterPostsByPrice(filter);
+    let getPostsResponse = await postController.filterPostsByPrice(filter);
+    console.log(getPostsResponse)
     getPostsResponse.posts[0].price = Number(getPostsResponse.posts[0].price);
     expectedPost.created = getPostsResponse.posts[0].created;
 
     expect(getPostsResponse.posts).toEqual([expectedPost]);
+  });
 
-    filter = {
+  test('filter posts by price, where price is not in price range', async () => {
+    const post = PostFactory.fakeTemplate();
+    post.user = UserFactory.fakeTemplate();
+
+    await new DataFactory()
+      .createPosts(post)
+      .createUsers(post.user)
+      .write();
+
+    let filter = {
       lowerBound: 1.0,
       upperBound: 2.0,
     };
 
-    getPostsResponse = await postController.filterPostsByPrice(filter);
+    let getPostsResponse = await postController.filterPostsByPrice(filter);
 
     expect(getPostsResponse.posts).toEqual([])
   });

--- a/src/types/ApiRequests.ts
+++ b/src/types/ApiRequests.ts
@@ -79,6 +79,11 @@ export interface FilterPostsRequest {
     category: string;
 }
 
+export interface FilterPostsByPriceRequest {
+    lowerBound: number;
+    upperBound: number;
+}
+
 // GENERAL IMAGES
 
 export interface UploadImageRequest {


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

Added a price filter so that users can filter posts by a price range.



## Changes Made

Users can put in a lower bound and upper bound for their price range. Then, they can view all of the posts that are within that price range.



## Test Coverage

I tested the feature through manual testing and unit testing. I used the same logic for both forms of testing. First, I tested a case that the price of a post is strictly between the lower bound and the upper bound. Next, I tested the two cases where the price is exactly equal to the lower bound and upper bound. Lastly, I tested the case where the price is not within the price range.