### PR TITLE
Fix bookmarks

### DIFF
--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -53,7 +53,9 @@ export class UserRepository extends AbstractRepository<UserModel> {
       (savedPost) => savedPost.id === post.id
     );
     if (postIndex === -1) {
-      throw Error("Tried to unsave post that user has not saved.");
+      throw new NotFoundError(
+        "Tried to unsave post that was not found in user's saved posts."
+      );
     }
     user.saved.splice(postIndex, 1);
     await this.repository.save(user);


### PR DESCRIPTION
## Overview
Fix BE bookmark deletion.

Right here the `.splice` method is being used with the `indexOf` operator. The issue is that `indexOf` returns `-1` if the post is not found in the user’s saved posts. But splice will treat `-1` as the last index of the array, and not throw an error, so it just removes the last bookmarked index.

Fix by throwing an exception when `-1` is the found index. Also compares posts by IDs only which should be more reliable than comparing the entire object. Lastly, adds `1` as the second argument to `.splice` so it only deletes one item!
## Testing
Trust me bro