### PR TITLE
Unsaving correct post (no longer LIFO)

### DIFF
--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -42,8 +42,11 @@ export class UserRepository extends AbstractRepository<UserModel> {
   }
 
   public async unsavePost(user: UserModel, post: PostModel): Promise<PostModel> {
-    user.saved.splice(user.saved.indexOf(post));
-    await this.repository.save(user);
+    const index = user.saved.findIndex(savedPost => savedPost.id === post.id);
+    if (index !== -1) {
+        user.saved.splice(index, 1);
+        await this.repository.save(user);
+    }
     return post;
   }
 


### PR DESCRIPTION
## Overview

When a user unsaves a post, the correct post is unsaved from their saved tab. Was previously removing the most recently saved post, but now removes the correct one.

## Changes Made

unsavePost method was previously using indexOf() method, and it was always returning -1 (meaning post does not exist), as there were two different instances of the post. In order to fix this, indexOf() was replaced by findIndex() and a condition that checked that the previous method did not return a -1.

## Test Coverage

This feature was tested through unit testing. There were multiple tests added in order to check certain cases that were not considered previously, such as **unsave middle post**. 

## Next Steps

This is part of bookmark logic, currently working on not being able to see any saved posts from someone you have blocked or vice versa.