### PR TITLE
Refactoring Chats

### DIFF
--- a/src/api/controllers/ChatController.ts
+++ b/src/api/controllers/ChatController.ts
@@ -17,7 +17,7 @@ export const updateFirestore = async (
   const now = new Date();
   if (!exists) {
     const data = {
-      "listingID":chatBody.listindId,
+      "listingID":chatBody.listingId,
       "buyerID": chatBody.buyerId,
       "sellerID": chatBody.sellerId,
       "userIDs": [chatBody.buyerId, chatBody.sellerId],  

--- a/src/api/controllers/ChatController.ts
+++ b/src/api/controllers/ChatController.ts
@@ -73,6 +73,7 @@ export class ChatController {
     if (doc.exists){
       const userCheck = await checkUsers(chatId,user.firebaseUid);
       if (!userCheck){
+        //TODO: factor this part out into a checkPermissions function that we can call in all the route
         throw new ForbiddenError("This user is not part of this chat");
       }
       

--- a/src/api/controllers/ChatController.ts
+++ b/src/api/controllers/ChatController.ts
@@ -1,0 +1,157 @@
+import { Body, CurrentUser, Delete, Get, HeaderParam, JsonController, Params, Post } from 'routing-controllers';
+import * as admin from 'firebase-admin';
+import { getFirestore, Timestamp, FieldValue, Filter } from 'firebase-admin/firestore';
+import { ChatParam, ChatReadParam, FirebaseUidParam } from '../validators/GenericRequests';
+import { CreateChatMessage,CreateAvailabilityChat, ChatResponse, CreateProposalChat, RespondProposalChat } from '../../types';
+
+//will this be an issue I can't read the env variable
+const serviceAccount = require("./firebase-admin-service-account.json");
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+  
+  });
+}
+const db = getFirestore();
+const chatsRef = db.collection('chats_refactored');
+export const updateFirestore = async (
+  chatId: string,
+  exists:boolean,
+  chatBody: any,
+  message: any,
+  chatsRef: any,
+  lastMessage:any,
+) => {
+  const now = new Date();
+  if (!exists) {
+    const data = {
+      "listingID":chatBody.listindId,
+      "buyerID": chatBody.buyerId,
+      "sellerID": chatBody.sellerId,
+      "userIDs": [chatBody.buyerId, chatBody.sellerId],  
+      "lastMessage": lastMessage,
+      "updatedAt": now,
+      }
+    await chatsRef.doc(chatId).set(data);
+    // Add a document to the subcollection
+    const subcollectionRef = chatsRef.doc(chatId).collection('messages');
+
+    await subcollectionRef.add(message);
+      
+    
+    console.log('Created new chat document!');
+  } else {
+    const subcollectionRef = chatsRef.doc(chatId).collection('messages');
+
+    await subcollectionRef.add(message);
+   
+  }
+}
+
+@JsonController('chat/')
+export class ChatController {
+
+  @Post('message/:id')
+  //chose the return to be any since the chat response will vary a lot 
+  async postChat(@Params() params: ChatParam,@Body() chatBody: CreateChatMessage): Promise<any>{
+    const chatId = params.id;
+    const doc = await chatsRef.doc(chatId).get();
+    const now = new Date();
+    const message = {
+      "type": "message",
+      "senderID": chatBody.senderId,
+      "text": chatBody.text,
+      "images": chatBody.images,
+      "timestamp": now,
+      "read": false
+    }
+    updateFirestore(chatId,doc.exists,chatBody,message,chatsRef,chatBody.text);
+    //returning the whole chat resutls in maximum call stack exceeded
+    return message;
+    
+  }
+
+  @Post('availability/:id')
+  async postAvailability(@Params() params: ChatParam,@Body() chatBody: CreateAvailabilityChat): Promise<any>{
+    console.log('here');
+    const chatId = params.id;
+    const doc = await chatsRef.doc(chatId).get();
+    const now = new Date();
+    const message = {
+      "type": "availability",
+      "senderID": chatBody.senderId,
+      "timestamp": now,
+      "availabilities":chatBody.availabilities,
+    }
+    updateFirestore(chatId,doc.exists,chatBody,message,chatsRef,"");
+
+    return message;
+  }
+
+  @Post('proposal/initial/:id')
+  async sendProposal(@Params() params: ChatParam,@Body() chatBody: CreateProposalChat): Promise<any>{
+    console.log('here');
+    const chatId = params.id;
+    const doc = await chatsRef.doc(chatId).get();
+    const now = new Date();
+    const message = {
+      "type": "proposal",
+      "senderID": chatBody.senderId,
+      "timestamp": now,
+      "accepted":null,
+      "startDate":chatBody.startDate,
+      "endDate":chatBody.endDate,
+    }
+    updateFirestore(chatId,doc.exists,chatBody,message,chatsRef,"");
+    return message;
+  }
+
+
+  @Post('proposal/:id')
+  async respondProposal(@Params() params: ChatParam,@Body() chatBody: RespondProposalChat): Promise<any>{
+    console.log('here');
+    const chatId = params.id;
+    const doc = await chatsRef.doc(chatId).get();
+    const now = new Date();
+    const message = {
+      "type": "proposal",
+      "senderID": chatBody.senderId,
+      "timestamp": now,
+      "accepted":chatBody.accepted,
+      "startDate":chatBody.startDate,
+      "endDate":chatBody.endDate,
+    }
+    updateFirestore(chatId,doc.exists,chatBody,message,chatsRef,"");
+   
+    return message;
+  }
+
+
+  @Post(':chatId/message/:messageId')
+  async markAsRead(@Params() params: ChatReadParam): Promise<any>{
+    console.log('here');
+    const chatId = params.chatId;
+    const doc = await chatsRef.doc(chatId).get();
+   
+    if (!doc.exists) {
+      console.log('No such document!');
+      return {"read":false}
+    } else {
+      const subDocRef = chatsRef.doc(chatId)     // Main collection document
+        .collection('messages') // Subcollection
+        .doc(params.messageId);     // Subcollection document ID
+
+      await subDocRef.update({
+        read: true
+      });
+
+      await chatsRef.doc(chatId).update({
+        updatedAt: new Date(),
+      })
+    }
+    return {"read":true}
+  }
+
+  
+}
+

--- a/src/api/controllers/ChatController.ts
+++ b/src/api/controllers/ChatController.ts
@@ -37,13 +37,16 @@ export const updateFirestore = async (
     const subcollectionRef = chatsRef.doc(chatId).collection('messages');
 
     await subcollectionRef.add(message);
-      
     
     console.log('Created new chat document!');
   } else {
     const subcollectionRef = chatsRef.doc(chatId).collection('messages');
-
     await subcollectionRef.add(message);
+    if (lastMessage!=''){
+      await chatsRef.doc(chatId).update({
+        lastMessage: lastMessage,
+      })
+    }
    
   }
 }

--- a/src/api/controllers/ChatController.ts
+++ b/src/api/controllers/ChatController.ts
@@ -1,19 +1,8 @@
 import { Body, CurrentUser, JsonController, Params, Post } from 'routing-controllers';
-import * as admin from 'firebase-admin';
 import { getFirestore, Timestamp, FieldValue, Filter } from 'firebase-admin/firestore';
 import { ChatParam, ChatReadParam } from '../validators/GenericRequests';
-import { CreateChatMessage,CreateAvailabilityChat, CreateProposalChat, RespondProposalChat, MessageResponse, AvailabilityResponse, ChatResponse } from '../../types';
-import dotenv from 'dotenv';
-//will this be an issue I can't read the env variable
-dotenv.config();
-var serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH!;
-const serviceAccount = require(serviceAccountPath);
-if (!admin.apps.length) {
-  admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
-  
-  });
-}
+import { CreateChatMessage,CreateAvailabilityChat, CreateProposalChat, RespondProposalChat, MessageResponse, AvailabilityResponse, ChatResponse, ProposalResponse, ChatReadResponse } from '../../types';
+
 const db = getFirestore();
 const chatsRef = db.collection('chats_refactored');
 export const updateFirestore = async (
@@ -78,7 +67,6 @@ export class ChatController {
 
   @Post('availability/:id')
   async postAvailability(@Params() params: ChatParam,@Body() chatBody: CreateAvailabilityChat): Promise<AvailabilityResponse>{
-    console.log('here');
     const chatId = params.id;
     const doc = await chatsRef.doc(chatId).get();
     const now = new Date();
@@ -94,8 +82,7 @@ export class ChatController {
   }
 
   @Post('proposal/initial/:id')
-  async sendProposal(@Params() params: ChatParam,@Body() chatBody: CreateProposalChat): Promise<any>{
-    console.log('here');
+  async sendProposal(@Params() params: ChatParam,@Body() chatBody: CreateProposalChat): Promise<ProposalResponse>{
     const chatId = params.id;
     const doc = await chatsRef.doc(chatId).get();
     const now = new Date();
@@ -113,8 +100,7 @@ export class ChatController {
 
 
   @Post('proposal/:id')
-  async respondProposal(@Params() params: ChatParam,@Body() chatBody: RespondProposalChat): Promise<any>{
-    console.log('here');
+  async respondProposal(@Params() params: ChatParam,@Body() chatBody: RespondProposalChat): Promise<ProposalResponse>{
     const chatId = params.id;
     const doc = await chatsRef.doc(chatId).get();
     const now = new Date();
@@ -127,14 +113,12 @@ export class ChatController {
       "endDate":chatBody.endDate,
     }
     updateFirestore(chatId,doc.exists,chatBody,message,chatsRef,"");
-    const ret = await chatsRef.doc(chatId).get();
-    return ret.data();
+    return message;
   }
 
 
   @Post(':chatId/message/:messageId')
-  async markAsRead(@Params() params: ChatReadParam): Promise<any>{
-    console.log('here');
+  async markAsRead(@Params() params: ChatReadParam): Promise<ChatReadResponse>{
     const chatId = params.chatId;
     const doc = await chatsRef.doc(chatId).get();
    

--- a/src/api/controllers/ChatController.ts
+++ b/src/api/controllers/ChatController.ts
@@ -1,7 +1,7 @@
 import { Body, CurrentUser, ForbiddenError, JsonController, Params, Post } from 'routing-controllers';
-import { getFirestore, Timestamp, FieldValue, Filter } from 'firebase-admin/firestore';
+import { getFirestore } from 'firebase-admin/firestore';
 import { ChatParam, ChatReadParam } from '../validators/GenericRequests';
-import { CreateChatMessage,CreateAvailabilityChat, CreateProposalChat, RespondProposalChat, MessageResponse, AvailabilityResponse, ChatResponse, ProposalResponse, ChatReadResponse } from '../../types';
+import { CreateChatMessage,CreateAvailabilityChat, CreateProposalChat, RespondProposalChat, MessageResponse, AvailabilityResponse, ProposalResponse, ChatReadResponse } from '../../types';
 import { UserModel } from '../../models/UserModel';
 
 const db = getFirestore();

--- a/src/api/controllers/index.ts
+++ b/src/api/controllers/index.ts
@@ -9,9 +9,11 @@ import { NotifController } from './NotifController'
 import { ReportController } from './ReportController';
 import { TransactionController } from './TransactionController';
 import { TransactionReviewController } from './TransactionReviewController';
+import { ChatController } from './ChatController';
 
 export const controllers = [
   AuthController,
+  ChatController,
   FeedbackController,
   ImageController,
   NotifController,

--- a/src/api/validators/GenericRequests.ts
+++ b/src/api/validators/GenericRequests.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsUUID } from 'class-validator';
+import { IsEmail, IsNumber, IsString, IsUUID } from 'class-validator';
 
 import { Uuid } from '../../types';
 
@@ -12,6 +12,18 @@ export class UuidParam {
   id: Uuid;
 }
 
+export class ChatParam {
+  @IsString()
+  id: string;
+}
+
+export class ChatReadParam {
+  @IsString()
+  chatId: string;
+  @IsString()
+  messageId:string;
+}
+
 export class TimeParam {
   @IsUUID()
   id: Uuid;
@@ -19,5 +31,6 @@ export class TimeParam {
 }
 
 export class FirebaseUidParam {
+  @IsString()
   id: string;
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,25 +8,10 @@ import { Container } from 'typeorm-typedi-extensions';
 import { Express } from 'express';
 import * as swaggerUi from 'swagger-ui-express';
 import * as path from 'path';
-
-import { controllers } from './api/controllers';
-import { middlewares } from './api/middlewares';
-import { UserModel } from './models/UserModel';
-import { ReportPostRequest, ReportProfileRequest, ReportMessageRequest } from './types';
-import { GetReportsResponse, Report } from './types/ApiResponses';
-import { ReportController } from './api/controllers/ReportController';
-import resellConnection from './utils/DB';
-import { ReportService } from './services/ReportService';
-import { ReportRepository } from './repositories/ReportRepository';
-import { reportToString } from './utils/Requests';
-import { CurrentUserChecker } from 'routing-controllers/types/CurrentUserChecker';
 import * as admin from 'firebase-admin';
-
-
 dotenv.config();
 var serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH!;
 const serviceAccount = require(serviceAccountPath);
-
 
 if (!serviceAccountPath) {
   throw new Error('FIREBASE_SERVICE_ACCOUNT_PATH environment variable is not set.');
@@ -41,6 +26,19 @@ if (!admin.apps.length) {
 
 
 export { admin };  // Export the admin instance
+
+import { controllers } from './api/controllers';
+import { middlewares } from './api/middlewares';
+import { UserModel } from './models/UserModel';
+import { ReportPostRequest, ReportProfileRequest, ReportMessageRequest } from './types';
+import { GetReportsResponse, Report } from './types/ApiResponses';
+import { ReportController } from './api/controllers/ReportController';
+import resellConnection from './utils/DB';
+import { ReportService } from './services/ReportService';
+import { ReportRepository } from './repositories/ReportRepository';
+import { reportToString } from './utils/Requests';
+import { CurrentUserChecker } from 'routing-controllers/types/CurrentUserChecker';
+
 
 async function main() {
   routingUseContainer(Container);

--- a/src/types/ApiRequests.ts
+++ b/src/types/ApiRequests.ts
@@ -206,4 +206,49 @@ export interface CreateTransactionReviewRequest {
     issueCategory?: string | null;
     issueDetails?: string | null;
 }
+
+export interface CreateChatMessage {
+    type: string;
+    listindId: Uuid;
+    buyerId: Uuid;
+    sellerId: Uuid;
+    senderId: Uuid;
+    text: string;
+    images:string[]
+}
+
+export interface CreateAvailabilityChat {
+    type: string;
+    listindId: Uuid;
+    buyerId: Uuid;
+    sellerId: Uuid;
+    senderId: Uuid,
+    availabilities:AvailabilityList[] //TODO: not sure if this works
+}
+
+export interface AvailabilityList {
+    startDate: Date;
+    endDate: Date;
+}
+  
+export interface CreateProposalChat {
+    type: string;
+    listindId: Uuid;
+    buyerId: Uuid;
+    sellerId: Uuid;
+    senderId: Uuid,
+    startDate: Date;
+    endDate: Date;
+}
+
+export interface RespondProposalChat {
+    type: string;
+    listindId: Uuid;
+    buyerId: Uuid;
+    sellerId: Uuid;
+    senderId: Uuid,
+    startDate: Date;
+    endDate: Date;
+    accepted: boolean
+}
   

--- a/src/types/ApiRequests.ts
+++ b/src/types/ApiRequests.ts
@@ -209,7 +209,7 @@ export interface CreateTransactionReviewRequest {
 
 export interface CreateChatMessage {
     type: string;
-    listindId: Uuid;
+    listingId: Uuid;
     buyerId: Uuid;
     sellerId: Uuid;
     senderId: Uuid;
@@ -219,7 +219,7 @@ export interface CreateChatMessage {
 
 export interface CreateAvailabilityChat {
     type: string;
-    listindId: Uuid;
+    listingId: Uuid;
     buyerId: Uuid;
     sellerId: Uuid;
     senderId: Uuid,
@@ -233,7 +233,7 @@ export interface AvailabilityList {
   
 export interface CreateProposalChat {
     type: string;
-    listindId: Uuid;
+    listingId: Uuid;
     buyerId: Uuid;
     sellerId: Uuid;
     senderId: Uuid,
@@ -243,7 +243,7 @@ export interface CreateProposalChat {
 
 export interface RespondProposalChat {
     type: string;
-    listindId: Uuid;
+    listingId: Uuid;
     buyerId: Uuid;
     sellerId: Uuid;
     senderId: Uuid,

--- a/src/types/ApiResponses.ts
+++ b/src/types/ApiResponses.ts
@@ -181,3 +181,25 @@ export interface GetReportResponse {
 export interface GetReportsResponse {
   reports: Report[];
 }
+
+//CHATS
+
+export interface ChatResponse {
+  listingID:Uuid,
+  buyerID:Uuid,
+  sellerID:Uuid,
+  userIDs: Uuid[],  // For easy querying - frontend can see all the chats you are part of
+  lastMessage:string,
+  updatedAt: Date,
+  messages: MessageRefactored[]
+
+}
+
+export interface MessageRefactored { //need to change s.t. this can be multiple formats
+  id: Uuid;
+  senderID: Uuid;
+  text: string;
+  timestamp: Date;
+  images: string[],
+  read:boolean
+}

--- a/src/types/ApiResponses.ts
+++ b/src/types/ApiResponses.ts
@@ -216,21 +216,3 @@ export interface ChatReadResponse {
   read:boolean
 
 }
-
-export interface ChatResponse {
-  listingID:Uuid,
-  buyerID:Uuid,
-  sellerID:Uuid,
-  userIDs: Uuid[],  // For easy querying - frontend can see all the chats you are part of
-  lastMessage:string,
-  updatedAt: Date,
-}
-
-// export interface MessageRefactored { //need to change s.t. this can be multiple formats
-//   id: Uuid;
-//   senderID: Uuid;
-//   text: string;
-//   timestamp: Date;
-//   images: string[],
-//   read:boolean
-// }

--- a/src/types/ApiResponses.ts
+++ b/src/types/ApiResponses.ts
@@ -1,6 +1,6 @@
 import { FeedbackModel } from "src/models/FeedbackModel";
 
-import { Uuid } from ".";
+import { AvailabilityList, Uuid } from ".";
 import { PostModel } from "../models/PostModel";
 import { UserModel } from "../models/UserModel";
 import { ReportModel } from "../models/ReportModel";
@@ -184,16 +184,32 @@ export interface GetReportsResponse {
 
 //CHATS
 
-// export interface ChatResponse {
-//   listingID:Uuid,
-//   buyerID:Uuid,
-//   sellerID:Uuid,
-//   userIDs: Uuid[],  // For easy querying - frontend can see all the chats you are part of
-//   lastMessage:string,
-//   updatedAt: Date,
-//   messages: MessageRefactored[]
+export interface MessageResponse {
+  type: string,
+  senderID: Uuid,
+  text: string,
+  images: string[],
+  timestamp: Date,
+  read: boolean
 
-// }
+}
+
+export interface AvailabilityResponse {
+  type: string,
+  senderID: Uuid,
+  timestamp: Date,
+  availabilities: AvailabilityList[]
+
+}
+
+export interface ChatResponse {
+  listingID:Uuid,
+  buyerID:Uuid,
+  sellerID:Uuid,
+  userIDs: Uuid[],  // For easy querying - frontend can see all the chats you are part of
+  lastMessage:string,
+  updatedAt: Date,
+}
 
 // export interface MessageRefactored { //need to change s.t. this can be multiple formats
 //   id: Uuid;

--- a/src/types/ApiResponses.ts
+++ b/src/types/ApiResponses.ts
@@ -202,6 +202,21 @@ export interface AvailabilityResponse {
 
 }
 
+export interface ProposalResponse {
+  type: string,
+  senderID: Uuid,
+  timestamp: Date,
+  accepted:boolean|null,
+  startDate:Date,
+  endDate:Date
+
+}
+
+export interface ChatReadResponse {
+  read:boolean
+
+}
+
 export interface ChatResponse {
   listingID:Uuid,
   buyerID:Uuid,

--- a/src/types/ApiResponses.ts
+++ b/src/types/ApiResponses.ts
@@ -184,22 +184,22 @@ export interface GetReportsResponse {
 
 //CHATS
 
-export interface ChatResponse {
-  listingID:Uuid,
-  buyerID:Uuid,
-  sellerID:Uuid,
-  userIDs: Uuid[],  // For easy querying - frontend can see all the chats you are part of
-  lastMessage:string,
-  updatedAt: Date,
-  messages: MessageRefactored[]
+// export interface ChatResponse {
+//   listingID:Uuid,
+//   buyerID:Uuid,
+//   sellerID:Uuid,
+//   userIDs: Uuid[],  // For easy querying - frontend can see all the chats you are part of
+//   lastMessage:string,
+//   updatedAt: Date,
+//   messages: MessageRefactored[]
 
-}
+// }
 
-export interface MessageRefactored { //need to change s.t. this can be multiple formats
-  id: Uuid;
-  senderID: Uuid;
-  text: string;
-  timestamp: Date;
-  images: string[],
-  read:boolean
-}
+// export interface MessageRefactored { //need to change s.t. this can be multiple formats
+//   id: Uuid;
+//   senderID: Uuid;
+//   text: string;
+//   timestamp: Date;
+//   images: string[],
+//   read:boolean
+// }

--- a/swagger.json
+++ b/swagger.json
@@ -2306,6 +2306,141 @@
           }
         }
       }
+    },
+    "/chat/message/{id}": {
+      "post": {
+        "tags": ["Chat"],
+        "summary": "Create a new message chat",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateChatMessage" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Chat message created",
+            "content": {
+              "application/json": {
+                "schema": {
+                   "$ref": "#/components/schemas/MessageResponse" 
+                  
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chat/availability/{id}": {
+      "post": {
+        "tags": ["Chat"],
+        "summary": "Create a new availability chat",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateAvailabilityChat" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Chat message created",
+            "content": {
+              "application/json": {
+                "schema": {
+                   "$ref": "#/components/schemas/AvailabilityResponse" 
+                  
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chat/proposal/initial/{id}": {
+      "post": {
+        "tags": ["Chat"],
+        "summary": "Create an initial proposal chat",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateProposalChat" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Chat message created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  
+                     "$ref": "#/components/schemas/ProposalResponse" 
+                  
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/chat/proposal/{id}": {
+      "post": {
+        "tags": ["Chat"],
+        "summary": "Respond to a proposal chat",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RespondProposalChat" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Chat message created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProposalResponse" 
+                  
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    ,
+
+    "/chat/{chatId}/message/{messageId}": {
+      "post": {
+        "tags": ["Chat"],
+        "summary": "Marks a message in a chat as read",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Chat message read",
+            "content": {
+              "application/json": {
+                "schema": {
+                 "$ref": "#/components/schemas/ReadResponse" 
+                  
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -3022,6 +3157,127 @@
           }
         }
       },
+      
+        "CreateChatMessage": {
+          "type": "object",
+          "required": ["type", "listindId", "buyerId", "sellerId", "senderId", "text", "images"],
+          "properties": {
+            "type": { "type": "string" },
+            "listindId": { "type": "string", "format": "uuid" },
+            "buyerId": { "type": "string", "format": "uuid" },
+            "sellerId": { "type": "string", "format": "uuid" },
+            "senderId": { "type": "string", "format": "uuid" },
+            "text": { "type": "string" },
+            "images": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "AvailabilityList": {
+          "type": "object",
+          "required": ["startDate", "endDate"],
+          "properties": {
+            "startDate": { "type": "string", "format": "date-time" },
+            "endDate": { "type": "string", "format": "date-time" }
+          }
+        },
+        "CreateAvailabilityChat": {
+          "type": "object",
+          "required": ["type", "listindId", "buyerId", "sellerId", "senderId", "availabilities"],
+          "properties": {
+            "type": { "type": "string" },
+            "listindId": { "type": "string", "format": "uuid" },
+            "buyerId": { "type": "string", "format": "uuid" },
+            "sellerId": { "type": "string", "format": "uuid" },
+            "senderId": { "type": "string", "format": "uuid" },
+            "availabilities": {
+              "type": "array",
+              "items": { "$ref": "#/components/schemas/AvailabilityList" }
+            }
+          }
+        },
+        "CreateProposalChat": {
+          "type": "object",
+          "required": ["type", "listindId", "buyerId", "sellerId", "senderId", "startDate", "endDate"],
+          "properties": {
+            "type": { "type": "string" },
+            "listindId": { "type": "string", "format": "uuid" },
+            "buyerId": { "type": "string", "format": "uuid" },
+            "sellerId": { "type": "string", "format": "uuid" },
+            "senderId": { "type": "string", "format": "uuid" },
+            "startDate": { "type": "string", "format": "date-time" },
+            "endDate": { "type": "string", "format": "date-time" }
+          }
+        },
+        "RespondProposalChat": {
+          "type": "object",
+          "required": ["type", "listindId", "buyerId", "sellerId", "senderId", "startDate", "endDate", "accepted"],
+          "properties": {
+            "type": { "type": "string" },
+            "listindId": { "type": "string", "format": "uuid" },
+            "buyerId": { "type": "string", "format": "uuid" },
+            "sellerId": { "type": "string", "format": "uuid" },
+            "senderId": { "type": "string", "format": "uuid" },
+            "startDate": { "type": "string", "format": "date-time" },
+            "endDate": { "type": "string", "format": "date-time" },
+            "accepted": { "type": "boolean" }
+          }
+        }
+      
+,
+
+  "MessageResponse": {
+    "type": "object",
+    "required": ["type", "senderID", "text", "images", "timestamp", "read"],
+    "properties": {
+      "type": { "type": "string" },
+      "senderID": { "type": "string", "format": "uuid" },
+      "text": { "type": "string" },
+      "images": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "timestamp": { "type": "string", "format": "date-time" },
+      "read": { "type": "boolean" }
+    }
+  },
+  "AvailabilityResponse": {
+    "type": "object",
+    "required": ["type", "senderID", "timestamp", "availabilities"],
+    "properties": {
+      "type": { "type": "string" },
+      "senderID": { "type": "string", "format": "uuid" },
+      "timestamp": { "type": "string", "format": "date-time" },
+      "availabilities": {
+        "type": "array",
+        "items": { "$ref": "#/components/schemas/AvailabilityList" }
+      }
+    }
+  },
+  "ProposalResponse": {
+    "type": "object",
+    "required": ["type", "senderID", "timestamp", "startDate", "endDate"],
+    "properties": {
+      "type": { "type": "string" },
+      "senderID": { "type": "string", "format": "uuid" },
+      "timestamp": { "type": "string", "format": "date-time" },
+      "accepted": { 
+        "type": ["boolean", "null"],
+        "nullable": true
+      },
+      "startDate": { "type": "string", "format": "date-time" },
+      "endDate": { "type": "string", "format": "date-time" }
+    }
+  }
+,
+"ReadResponse": {
+    "type": "object",
+    "required": ["read"],
+    "properties": {
+      "read": { "type": "boolean" }
+    }
+  },
       "PrivateProfile": {
         "type": "object",
         "properties": {

--- a/swagger.json
+++ b/swagger.json
@@ -3160,10 +3160,10 @@
       
         "CreateChatMessage": {
           "type": "object",
-          "required": ["type", "listindId", "buyerId", "sellerId", "senderId", "text", "images"],
+          "required": ["type", "listingId", "buyerId", "sellerId", "senderId", "text", "images"],
           "properties": {
             "type": { "type": "string" },
-            "listindId": { "type": "string", "format": "uuid" },
+            "listingId": { "type": "string", "format": "uuid" },
             "buyerId": { "type": "string", "format": "uuid" },
             "sellerId": { "type": "string", "format": "uuid" },
             "senderId": { "type": "string", "format": "uuid" },
@@ -3184,10 +3184,10 @@
         },
         "CreateAvailabilityChat": {
           "type": "object",
-          "required": ["type", "listindId", "buyerId", "sellerId", "senderId", "availabilities"],
+          "required": ["type", "listingId", "buyerId", "sellerId", "senderId", "availabilities"],
           "properties": {
             "type": { "type": "string" },
-            "listindId": { "type": "string", "format": "uuid" },
+            "listingId": { "type": "string", "format": "uuid" },
             "buyerId": { "type": "string", "format": "uuid" },
             "sellerId": { "type": "string", "format": "uuid" },
             "senderId": { "type": "string", "format": "uuid" },
@@ -3199,10 +3199,10 @@
         },
         "CreateProposalChat": {
           "type": "object",
-          "required": ["type", "listindId", "buyerId", "sellerId", "senderId", "startDate", "endDate"],
+          "required": ["type", "listingId", "buyerId", "sellerId", "senderId", "startDate", "endDate"],
           "properties": {
             "type": { "type": "string" },
-            "listindId": { "type": "string", "format": "uuid" },
+            "listingId": { "type": "string", "format": "uuid" },
             "buyerId": { "type": "string", "format": "uuid" },
             "sellerId": { "type": "string", "format": "uuid" },
             "senderId": { "type": "string", "format": "uuid" },
@@ -3212,10 +3212,10 @@
         },
         "RespondProposalChat": {
           "type": "object",
-          "required": ["type", "listindId", "buyerId", "sellerId", "senderId", "startDate", "endDate", "accepted"],
+          "required": ["type", "listingId", "buyerId", "sellerId", "senderId", "startDate", "endDate", "accepted"],
           "properties": {
             "type": { "type": "string" },
-            "listindId": { "type": "string", "format": "uuid" },
+            "listingId": { "type": "string", "format": "uuid" },
             "buyerId": { "type": "string", "format": "uuid" },
             "sellerId": { "type": "string", "format": "uuid" },
             "senderId": { "type": "string", "format": "uuid" },


### PR DESCRIPTION
To ease chat implementation on the frontend, backend will now serve as a "middle man" to help create messages and mark messages as read. Details as to design choices can be read here: https://www.notion.so/cornellappdev/Resell-s-Intervention-1a20e873f4fa80e99da9cd7cd3c0a23b

## Overview

I created a ChatsController that connected to the firestore database. Within ChatsController there are new routes to post messages and mark a message as read. 

## Changes Made

There are 4 kinds of messages: regular chats, availabilities, proposal (initial), proposal (accept/reject).

I create a POST request for each. These POST requests take in the request body, will check if the chatId already exists in firestore and if so, will add this new message to the messages subcollection in this existing chat. If not, it will create a new chat document and add this message as a subcollection to the new document. 

For the POST request to mark a message as read, I first check to see if a chatId exists in firestore. If it doesn't exist, the function will return {read: false}. Otherwise it will return {read:true}. 

For each request made to a chat that already exists, lastUpdate time will be updated. For POST requests for messages that are regular chats, the lastMessage field is also updated each time that endpoint is called. 

If a user is not part of the chat, trying to access it will throw a 403 error. 

## Screenshots (delete if not applicable)
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/881abbcd-2996-4a8d-b327-40f0739cc5a5" />
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/ea2f4c9f-ad40-47f7-9010-ec503aa88893" />
<img width="1156" alt="image" src="https://github.com/user-attachments/assets/cda59895-fd43-423f-ab80-7cff8482101e" />

<img width="935" alt="image" src="https://github.com/user-attachments/assets/5bddba6a-658b-4d3c-a1a5-340e7422acad" />