### PR TITLE
Adding searches table and storing searches functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "multer": "1.4.5-lts.1",
     "node-fetch": "^2.6.1",
     "pg": "^8.7.1",
+    "pgvector": "^0.2.0",
     "pug": "^3.0.2",
     "reflect-metadata": "^0.1.13",
     "routing-controllers": "0.10.2",

--- a/src/migrations/1743566564676-CreateSearchesTable.ts
+++ b/src/migrations/1743566564676-CreateSearchesTable.ts
@@ -1,0 +1,43 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CreateSearchesTable1743566564676 implements MigrationInterface {
+    name = 'CreateSearchesTable1743566564676'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Create the pgvector extension if it doesn't exist
+        await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS vector`);
+        
+        // Create the searches table
+        await queryRunner.query(`CREATE TABLE "searches" (
+            "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+            "searchText" character varying NOT NULL,
+            "searchVector" vector(512),
+            "firebaseUid" character varying NOT NULL,
+            "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+            CONSTRAINT "PK_searches" PRIMARY KEY ("id")
+        )`);
+        
+        // Add foreign key constraint to link to User table
+        await queryRunner.query(`ALTER TABLE "searches" 
+            ADD CONSTRAINT "FK_searches_user" 
+            FOREIGN KEY ("firebaseUid") 
+            REFERENCES "User"("firebaseUid") 
+            ON DELETE CASCADE`);
+            
+        // Create an index for vector similarity search
+        await queryRunner.query(`CREATE INDEX "idx_searches_vector" ON "searches" USING ivfflat (searchVector vector_cosine_ops)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Drop the index
+        await queryRunner.query(`DROP INDEX "idx_searches_vector"`);
+        
+        // Drop the foreign key constraint
+        await queryRunner.query(`ALTER TABLE "searches" DROP CONSTRAINT "FK_searches_user"`);
+        
+        // Drop the table
+        await queryRunner.query(`DROP TABLE "searches"`);
+        
+        // We don't drop the vector extension as it might be used by other tables
+    }
+}

--- a/src/migrations/1743566564676-CreateSearchesTable.ts
+++ b/src/migrations/1743566564676-CreateSearchesTable.ts
@@ -25,7 +25,7 @@ export class CreateSearchesTable1743566564676 implements MigrationInterface {
             ON DELETE CASCADE`);
             
         // Create an index for vector similarity search
-        await queryRunner.query(`CREATE INDEX "idx_searches_vector" ON "searches" USING ivfflat (searchVector vector_cosine_ops)`);
+        await queryRunner.query(`CREATE INDEX "idx_searches_vector" ON "searches" USING ivfflat ("searchVector" vector_cosine_ops)`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/models/SearchModel.ts
+++ b/src/models/SearchModel.ts
@@ -1,0 +1,31 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { UserModel } from "./UserModel";
+
+@Entity("searches")
+export class SearchModel {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column()
+  searchText: string;
+
+  @Column()
+  searchVector: string;
+
+  @Column()
+  firebaseUid: string;
+
+  @ManyToOne(() => UserModel, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "firebaseUid", referencedColumnName: "firebaseUid" })
+  user: UserModel;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,6 +9,7 @@ import { TransactionModel } from './TransactionModel';
 import { TransactionReviewModel } from './TransactionReviewModel';
 import { NotifModel } from './NotifModel';
 import { FcmTokenModel } from './FcmTokenModel';
+import { SearchModel } from './SearchModel';
 
 export const models = [
   FeedbackModel,
@@ -21,5 +22,6 @@ export const models = [
   TransactionModel,
   TransactionReviewModel,
   NotifModel,
-  FcmTokenModel
+  FcmTokenModel,
+  SearchModel,
 ];

--- a/src/repositories/SearchRepository.ts
+++ b/src/repositories/SearchRepository.ts
@@ -1,0 +1,93 @@
+import { AbstractRepository, EntityRepository } from 'typeorm';
+
+import { SearchModel } from '../models/SearchModel';
+import { UserModel } from '../models/UserModel';
+import { Uuid } from '../types';
+
+@EntityRepository(SearchModel)
+export class SearchRepository extends AbstractRepository<SearchModel> {
+  /**
+   * Get all searches
+   */
+  public async getAllSearches(): Promise<SearchModel[]> {
+    return await this.repository
+      .createQueryBuilder("search")
+      .leftJoinAndSelect("search.user", "user")
+      .getMany();
+  }
+
+  /**
+   * Get a search by its ID
+   */
+  public async getSearchById(id: Uuid): Promise<SearchModel | undefined> {
+    return await this.repository
+      .createQueryBuilder("search")
+      .leftJoinAndSelect("search.user", "user")
+      .where("search.id = :id", { id })
+      .getOne();
+  }
+
+  /**
+   * Get all searches by a specific user
+   */
+  public async getSearchesByUserId(firebaseUid: string): Promise<SearchModel[]> {
+    return await this.repository
+      .createQueryBuilder("search")
+      .leftJoinAndSelect("search.user", "user")
+      .where("search.firebaseUid = :firebaseUid", { firebaseUid })
+      .getMany();
+  }
+
+  /**
+   * Create a new search record
+   */
+  public async createSearch(
+    searchText: string,
+    searchVector: string,
+    firebaseUid: string
+  ): Promise<SearchModel> {
+    const search = new SearchModel();
+    search.searchText = searchText;
+    search.searchVector = searchVector;
+    search.firebaseUid = firebaseUid;
+    
+    return await this.repository.save(search);
+  }
+
+  /**
+   * Find similar searches based on vector similarity
+   * Note: This requires raw SQL as TypeORM doesn't natively support pgvector operations
+   */
+  public async findSimilarSearches(
+    searchVector: string,
+    limit: number = 5
+  ): Promise<SearchModel[]> {
+    // Using raw query to leverage pgvector's similarity search
+    // The vector data is passed as a string and converted in the query
+    return await this.repository
+      .createQueryBuilder("search")
+      .leftJoinAndSelect("search.user", "user")
+      .orderBy(`search.searchVector <-> '${searchVector}'`)
+      .limit(limit)
+      .getMany();
+  }
+
+  /**
+   * Delete a search by ID
+   */
+  public async deleteSearch(search: SearchModel): Promise<SearchModel> {
+    return await this.repository.remove(search);
+  }
+
+  /**
+   * Delete all searches by a user
+   */
+  public async deleteUserSearches(firebaseUid: string): Promise<void> {
+    await this.repository
+      .createQueryBuilder()
+      .delete()
+      .from(SearchModel)
+      .where("firebaseUid = :firebaseUid", { firebaseUid })
+      .execute();
+  }
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -10,6 +10,8 @@ import { TransactionRepository } from "./TransactionRepository";
 import { TransactionReviewRepository } from "./TransactionReviewRepository";
 import { NotifRepository } from "./NotifRepository"
 import { FcmTokenRepository } from "./FcmTokenRepository";
+import { SearchRepository } from "./SearchRepository";
+
 
 export default class Repositories {
   public static user(
@@ -70,6 +72,12 @@ export default class Repositories {
     transactionalEntityManager: EntityManager
   ): FcmTokenRepository {
     return transactionalEntityManager.getCustomRepository(FcmTokenRepository);
+  }
+
+  public static search(
+    transactionalEntityManager: EntityManager
+  ): SearchRepository {
+    return transactionalEntityManager.getCustomRepository(SearchRepository);
   }
 }
 

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -1,0 +1,86 @@
+import { getCustomRepository } from "typeorm";
+import { SearchRepository } from "../repositories/SearchRepository";
+import { getLoadedModel } from "../utils/SentenceEncoder";
+import { SearchModel } from "../models/SearchModel";
+
+export class SearchService {
+  private searchRepository: SearchRepository;
+
+  constructor() {
+    this.searchRepository = getCustomRepository(SearchRepository);
+  }
+
+  /**
+   * Create a search record with vectorized text using Universal Sentence Encoder
+   */
+  public async createSearch(searchText: string, firebaseUid: string): Promise<SearchModel> {
+    // Get the embedding model
+    const model = await getLoadedModel();
+    
+    // Generate embedding for the search text
+    const embedding = await model.embed([searchText]).then((embeddings: any) => {
+      // Convert tensor to array
+      const embeddingArray = embeddings.arraySync()[0];
+      // Convert array to string for storage
+      return JSON.stringify(embeddingArray);
+    });
+
+    // Create and save the search record
+    return await this.searchRepository.createSearch(
+      searchText,
+      embedding,
+      firebaseUid
+    );
+  }
+
+  /**
+   * Find similar searches based on text similarity
+   */
+  public async findSimilarSearches(searchText: string, limit: number = 5): Promise<SearchModel[]> {
+    // Get the embedding model
+    const model = await getLoadedModel();
+    
+    // Generate embedding for the search text
+    const embedding = await model.embed([searchText]).then((embeddings: any) => {
+      // Convert tensor to array
+      const embeddingArray = embeddings.arraySync()[0];
+      // Convert array to string for query
+      return JSON.stringify(embeddingArray);
+    });
+
+    // Find similar searches using vector similarity
+    return await this.searchRepository.findSimilarSearches(embedding, limit);
+  }
+
+  /**
+   * Get all searches
+   */
+  public async getAllSearches(): Promise<SearchModel[]> {
+    return await this.searchRepository.getAllSearches();
+  }
+
+  /**
+   * Get searches by user ID
+   */
+  public async getSearchesByUserId(firebaseUid: string): Promise<SearchModel[]> {
+    return await this.searchRepository.getSearchesByUserId(firebaseUid);
+  }
+
+  /**
+   * Delete a search by ID
+   */
+  public async deleteSearch(searchId: string): Promise<SearchModel | undefined> {
+    const search = await this.searchRepository.getSearchById(searchId);
+    if (!search) {
+      return undefined;
+    }
+    return await this.searchRepository.deleteSearch(search);
+  }
+
+  /**
+   * Delete all searches by a user
+   */
+  public async deleteUserSearches(firebaseUid: string): Promise<void> {
+    await this.searchRepository.deleteUserSearches(firebaseUid);
+  }
+}


### PR DESCRIPTION
## Overview

This pr added a searches table (vectorized) to the db and in the codebase, as well as adding the functionality to actually store the searches when a user searches something.

## Changes Made

- Created a migration to create the searches table in the db. It is using pgvector and still using Universal Sentence Encoder (if we fully commit to changing to Langchain from Tensorflow we are going to have to refactor this)
- Created a SearchModel
- Created a SearchRepository
- Created a SearchService
- Added these to corresponding index.ts files
- Added store searches functionality in the searchPosts endpoint in PostService

## Test Coverage

Need to add unit tests for this new model

## Next Steps (delete if not applicable)

This is the basics for what we need in order to implement endpoints to get post suggestions from a users searches and bookmarks. Need to do something similar for _browsing history_, as this covers _search history_ of the user.