### PR TITLE
Add backend support for getting token

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@tensorflow-models/universal-sentence-encoder": "^1.3.3",
     "@tensorflow/tfjs": "^4.2.0",
     "@tensorflow/tfjs-node": "^4.3.0",
+    "axios": "^1.8.4",
     "body-parser": "^1.19.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/src/api/controllers/AuthToken.ts
+++ b/src/api/controllers/AuthToken.ts
@@ -1,0 +1,28 @@
+import { Body, Get, JsonController } from 'routing-controllers';
+import { getAuth } from "firebase-admin/auth";
+import { AuthTokenResponse, FcmTokenRequest } from '../../types';
+import axios from "axios";
+@JsonController('authToken/')
+export class AuthTokenController {
+
+  @Get() async authorize(@Body() fcmToken: FcmTokenRequest): Promise<AuthTokenResponse> {
+  try {
+    const customToken = await getAuth().createCustomToken(fcmToken.token);
+
+    const res = await axios.post(
+      `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyDoA6LS50__vx9PsHk_olqlM_CInjJnG7o`,
+      {
+        token: customToken,
+        returnSecureToken: true,
+      }
+    );
+
+    const idToken = res.data.idToken;
+    return { token: idToken };
+  } catch (error) {
+    console.error('Error creating or exchanging custom token:', error);
+    throw error; 
+  }
+}
+
+}

--- a/src/api/controllers/index.ts
+++ b/src/api/controllers/index.ts
@@ -10,9 +10,11 @@ import { ReportController } from './ReportController';
 import { TransactionController } from './TransactionController';
 import { TransactionReviewController } from './TransactionReviewController';
 import { ChatController } from './ChatController';
+import { AuthTokenController } from './AuthToken';
 
 export const controllers = [
   AuthController,
+  AuthTokenController,
   ChatController,
   FeedbackController,
   ImageController,

--- a/src/types/ApiResponses.ts
+++ b/src/types/ApiResponses.ts
@@ -216,3 +216,8 @@ export interface ChatReadResponse {
   read:boolean
 
 }
+
+
+export interface AuthTokenResponse{
+  token:string
+}


### PR DESCRIPTION
added endpoint /api/authToken/ that takesn in an FCM token 

request body 
{
 token: fcmToken
}

and the response is the auth token 