### PR TITLE
Implement endpoint for post suggestions based on searches 

### DIFF
--- a/src/api/controllers/PostController.ts
+++ b/src/api/controllers/PostController.ts
@@ -144,4 +144,12 @@ export class PostController {
   ): Promise<GetPostsResponse> {
     return { posts: await this.postService.getSuggestedPosts(user, limit) };
   }
+
+  @Get('searchSuggestions/:searchIndex/:postCount/')
+  async getSearchSuggestions(
+    @Params() params: { searchIndex: string; postCount: number }
+  ): Promise<{ postIds: string[] }> {
+    const postIds = await this.postService.getSearchSuggestions(params.searchIndex, Number(params.postCount));
+    return { postIds };
+  }
 }

--- a/src/repositories/SearchRepository.ts
+++ b/src/repositories/SearchRepository.ts
@@ -90,4 +90,16 @@ export class SearchRepository extends AbstractRepository<SearchModel> {
       .where("firebaseUid = :firebaseUid", { firebaseUid })
       .execute();
   }
+
+  public async searchSuggestions(
+    searchText: string,
+    limit: number = 5
+  ): Promise<SearchModel[]> {
+    return await this.repository
+      .createQueryBuilder("search")
+      .leftJoinAndSelect("search.user", "user")
+      .where("search.searchText ILIKE :searchText", { searchText: `%${searchText}%` })
+      .limit(limit)
+      .getMany();
+  }
 }

--- a/src/services/PostService.ts
+++ b/src/services/PostService.ts
@@ -1,4 +1,3 @@
-import { Tensor2D } from '@tensorflow/tfjs';
 import { ForbiddenError, NotFoundError } from 'routing-controllers';
 import { Service } from 'typedi';
 import { EntityManager } from 'typeorm';
@@ -418,4 +417,35 @@ export class PostService {
       });
     });
   }
+
+  /**
+   * Get search suggestions based on vector similarity to a search's embedding
+   * Returns only post IDs, not full post data.
+   */
+  public async getSearchSuggestions(searchIndex: string, postCount: number): Promise<string[]> {
+    return this.transactions.readOnly(async (transactionalEntityManager) => {
+      const searchRepository = Repositories.search(transactionalEntityManager);
+      const postRepository = Repositories.post(transactionalEntityManager);
+      // Get the search by ID
+      const search = await searchRepository.getSearchById(searchIndex);
+        if (!search) throw new NotFoundError('Search not found!');
+        // Parse vector
+        const searchVector: number[] = JSON.parse(search.searchVector);
+        // Get active, unarchived posts
+        const allPosts = await postRepository.getAllPosts();
+        const model = await getLoadedModel();
+        // For each post, generate embedding from the title
+        const postEmbeddings = await model.embed(allPosts.map(p => p.title));
+        const embeddingsArray = postEmbeddings.arraySync();
+        // Find similarity
+        const scoredPosts = allPosts.map((post, idx) => ({
+          id: post.id,
+          similarity: this.similarity(searchVector, embeddingsArray[idx])
+        }));
+        // Sort by similarity (descending order) and choose top N
+        const topPosts = scoredPosts.sort((a, b) => b.similarity - a.similarity).slice(0, postCount);
+        return topPosts.map(p => p.id);
+    });
+  }
+  
 }


### PR DESCRIPTION
## Overview

Added a new GET endpoint called searchSuggestions to get suggestions **_from the user's searches_** parameterized by the index and number of posts to return (vectorized searches table).

- /**searchSuggestions/{searchIndex}/{postCount}**
- Returns a list of postIDs in the response body

## Changes Made

- Added a new GET route in the PostController (decided not to make new controller for Searches, but could be refactored later after we see how many routes would go in there)
- Calls a method in PostService that fetches the search by id, parses the vector, gets all active posts, and for each post generates its embedding. 
- Reused the similarity function used in similar posts to find that similarity between the search vector and the embedding (could also be refactored, just a starting point)

## Test Coverage

Still needs to be tested using postman. Can also make a test suite if needed.

## Next Steps

A similar route purchaseSuggestions should be implemented to complete the basic functionality for the homepage.