### PR TITLE
Debug chat last update time and categories migration

### DIFF
--- a/src/api/controllers/ChatController.ts
+++ b/src/api/controllers/ChatController.ts
@@ -39,6 +39,9 @@ export const updateFirestore = async (
         lastMessage: lastMessage,
       })
     }
+    await chatsRef.doc(chatId).update({
+      updatedAt: new Date(),
+    })
    
   }
 }
@@ -177,9 +180,7 @@ export class ChatController {
         read: true
       });
 
-      await chatsRef.doc(chatId).update({
-        updatedAt: new Date(),
-      })
+    
     }
     return {"read":true}
   }

--- a/src/migrations/1743028223060-AddCategoryTable.ts
+++ b/src/migrations/1743028223060-AddCategoryTable.ts
@@ -31,6 +31,23 @@ export class AddCategoryTable1743028223060 implements MigrationInterface {
       await queryRunner.query(`
         CREATE INDEX "IDX_1860e6d8b1a47e00c8c0ea937b" ON "post_categories" ("categories")
       `);
+
+       // Insert unique categories into the new Category table
+  await queryRunner.query(`
+    INSERT INTO "Category" ("name")
+    SELECT DISTINCT "category"
+    FROM "Post"
+    WHERE "category" IS NOT NULL
+  `);
+
+  // Create post-category relations
+  await queryRunner.query(`
+    INSERT INTO "post_categories" ("posts", "categories")
+    SELECT "Post"."id", "Category"."id"
+    FROM "Post"
+    JOIN "Category" ON "Post"."category" = "Category"."name"
+    WHERE "Post"."category" IS NOT NULL
+  `);
   
    
       await queryRunner.query(`
@@ -44,6 +61,18 @@ export class AddCategoryTable1743028223060 implements MigrationInterface {
     await queryRunner.query(`
         ALTER TABLE "Post" ADD "category" character varying NOT NULL
       `);
+
+      // Backfill category using first match from post_categories
+  await queryRunner.query(`
+    UPDATE "Post"
+    SET "category" = subquery."name"
+    FROM (
+      SELECT pc."posts" as post_id, c."name"
+      FROM "post_categories" pc
+      JOIN "Category" c ON pc."categories" = c."id"
+    ) AS subquery
+    WHERE "Post"."id" = subquery."post_id"
+  `);
   
 
       await queryRunner.query(`


### PR DESCRIPTION
## Last Update Time

Chats were previously updating the 'last update time' field on reads instead of on new chat messages. The vice versa should be true and I implemented these changes. Tested that this works!

## Categories migration
Categories migration dropped the category column before moving it over to the new categories column. I changed the migration file to address this but it is not tested since category column is already dropped.