### PR TITLE
Add server-side seller filtering for review list endpoints.

### DIFF
--- a/src/api/controllers/TransactionReviewController.ts
+++ b/src/api/controllers/TransactionReviewController.ts
@@ -21,8 +21,16 @@ export class TransactionReviewController {
   }
 
   @Get()
-  async getTransactionReviews(): Promise<{ reviews: TransactionReviewModel[] }> {
-    return { reviews: await this.transactionReviewService.getAllTransactionReviews() };
+  async getTransactionReviews(
+    @QueryParam("sellerId") sellerId?: string,
+  ): Promise<{ reviews: TransactionReviewModel[] }> {
+    return {
+      reviews: sellerId
+        ? await this.transactionReviewService.getTransactionReviewsBySellerId(
+            sellerId,
+          )
+        : await this.transactionReviewService.getAllTransactionReviews(),
+    };
   }
 
   @Get('id/:id/')

--- a/src/api/controllers/UserReviewController.ts
+++ b/src/api/controllers/UserReviewController.ts
@@ -1,4 +1,13 @@
-import { Body, CurrentUser, Delete, Get, JsonController, Params, Post } from 'routing-controllers';
+import {
+  Body,
+  CurrentUser,
+  Delete,
+  Get,
+  JsonController,
+  Params,
+  Post,
+  QueryParam,
+} from 'routing-controllers';
 import {
   CreateUserReviewRequest
 } from '../../types';
@@ -16,8 +25,14 @@ export class UserReviewController {
   }
 
   @Get()
-  async getUserReviews(): Promise<{ reviews: UserReviewModel[] }> {
-    return { reviews: await this.userReviewService.getAllUserReviews() };
+  async getUserReviews(
+    @QueryParam("sellerId") sellerId?: string,
+  ): Promise<{ reviews: UserReviewModel[] }> {
+    return {
+      reviews: sellerId
+        ? await this.userReviewService.getUserReviewsBySellerId(sellerId)
+        : await this.userReviewService.getAllUserReviews(),
+    };
   }
 
   @Get('id/:id/')

--- a/src/migrations/1770000000000-UserReviewBuyerSellerNotNull.ts
+++ b/src/migrations/1770000000000-UserReviewBuyerSellerNotNull.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UserReviewBuyerSellerNotNull1770000000000
+  implements MigrationInterface
+{
+  name = "UserReviewBuyerSellerNotNull1770000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const orphans: Array<{ id: string }> = await queryRunner.query(
+      `SELECT "id" FROM "UserReview" WHERE "buyerId" IS NULL OR "sellerId" IS NULL`,
+    );
+    if (orphans.length > 0) {
+      console.log(
+        `UserReviewBuyerSellerNotNull: removing ${orphans.length} UserReview rows missing buyer or seller before tightening constraints.`,
+      );
+      await queryRunner.query(
+        `DELETE FROM "UserReview" WHERE "buyerId" IS NULL OR "sellerId" IS NULL`,
+      );
+    }
+
+    await queryRunner.query(
+      `ALTER TABLE "UserReview" ALTER COLUMN "buyerId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "UserReview" ALTER COLUMN "sellerId" SET NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "UserReview" ALTER COLUMN "sellerId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "UserReview" ALTER COLUMN "buyerId" DROP NOT NULL`,
+    );
+  }
+}

--- a/src/models/UserReviewModel.ts
+++ b/src/models/UserReviewModel.ts
@@ -28,11 +28,15 @@ export class UserReviewModel {
   @CreateDateColumn({ type: "timestamptz" })
   date: Date;
 
-  @ManyToOne(() => UserModel, (buyer) => buyer.reviewsWritten)
+  @ManyToOne(() => UserModel, (buyer) => buyer.reviewsWritten, {
+    nullable: false,
+  })
   @JoinColumn({ name: "buyerId" })
   buyer: UserModel;
 
-  @ManyToOne(() => UserModel, (seller) => seller.reviewsReceived)
+  @ManyToOne(() => UserModel, (seller) => seller.reviewsReceived, {
+    nullable: false,
+  })
   @JoinColumn({ name: "sellerId" })
   seller: UserModel;
 

--- a/src/repositories/TransactionReviewRepository.ts
+++ b/src/repositories/TransactionReviewRepository.ts
@@ -11,6 +11,20 @@ export class TransactionReviewRepository extends AbstractRepository<TransactionR
     return await this.repository
       .createQueryBuilder("review")
       .leftJoinAndSelect("review.transaction", "transaction")
+      .leftJoinAndSelect("transaction.seller", "seller")
+      .leftJoinAndSelect("transaction.buyer", "buyer")
+      .getMany();
+  }
+
+  public async getTransactionReviewsBySellerId(
+    sellerId: Uuid,
+  ): Promise<TransactionReviewModel[]> {
+    return await this.repository
+      .createQueryBuilder("review")
+      .leftJoinAndSelect("review.transaction", "transaction")
+      .leftJoinAndSelect("transaction.seller", "seller")
+      .leftJoinAndSelect("transaction.buyer", "buyer")
+      .where("seller.firebaseUid = :sellerId", { sellerId })
       .getMany();
   }
 

--- a/src/repositories/UserReviewRepository.ts
+++ b/src/repositories/UserReviewRepository.ts
@@ -10,6 +10,18 @@ export class UserReviewRepository extends AbstractRepository<UserReviewModel> {
     return await this.repository
       .createQueryBuilder("review")
       .leftJoinAndSelect("review.buyer", "user")
+      .leftJoinAndSelect("review.seller", "seller")
+      .getMany();
+  }
+
+  public async getUserReviewsBySellerId(
+    sellerId: Uuid,
+  ): Promise<UserReviewModel[]> {
+    return await this.repository
+      .createQueryBuilder("review")
+      .leftJoinAndSelect("review.buyer", "user")
+      .leftJoinAndSelect("review.seller", "seller")
+      .where("seller.firebaseUid = :sellerId", { sellerId })
       .getMany();
   }
 

--- a/src/services/TransactionReviewService.ts
+++ b/src/services/TransactionReviewService.ts
@@ -27,6 +27,19 @@ export class TransactionReviewService {
     });
   }
 
+  public async getTransactionReviewsBySellerId(
+    sellerId: string,
+  ): Promise<TransactionReviewModel[]> {
+    return this.transactions.readOnly(async (transactionalEntityManager) => {
+      const transactionReviewRepository = Repositories.transactionReview(
+        transactionalEntityManager,
+      );
+      return await transactionReviewRepository.getTransactionReviewsBySellerId(
+        sellerId,
+      );
+    });
+  }
+
   // Get a transaction review by its ID
   public async getTransactionReviewById(
     params: UuidParam,

--- a/src/services/UserReviewService.ts
+++ b/src/services/UserReviewService.ts
@@ -26,6 +26,15 @@ export class UserReviewService {
     });
   }
 
+  public async getUserReviewsBySellerId(sellerId: string): Promise<UserReviewModel[]> {
+    return this.transactions.readOnly(async (transactionalEntityManager) => {
+      const userReviewRepository = Repositories.userReview(
+        transactionalEntityManager,
+      );
+      return await userReviewRepository.getUserReviewsBySellerId(sellerId);
+    });
+  }
+
   public async getUserReviewById(params: UuidParam): Promise<UserReviewModel> {
     return this.transactions.readOnly(async (transactionalEntityManager) => {
       const userReviewRepository = Repositories.userReview(

--- a/src/tests/TransactionReviewTest.test.ts
+++ b/src/tests/TransactionReviewTest.test.ts
@@ -8,6 +8,7 @@ import {
   DataFactory,
   TransactionFactory,
   TransactionReviewFactory,
+  UserFactory,
 } from "./data";
 import { CreateTransactionReviewRequest } from "src/types";
 
@@ -110,5 +111,41 @@ describe('transaction review tests', () => {
 
     const response = await transactionReviewController.getTransactionReviews();
     expect(response.reviews).toHaveLength(2);
+  });
+
+  test("get transaction reviews filtered by sellerId", async () => {
+    const seller = UserFactory.fakeTemplate2();
+    const buyer = UserFactory.fakeTemplate();
+    const otherSeller = UserFactory.fake();
+    const otherBuyer = UserFactory.fake();
+
+    const matchingTransaction = TransactionFactory.fake();
+    matchingTransaction.seller = seller;
+    matchingTransaction.buyer = buyer;
+
+    const otherTransaction = TransactionFactory.fake();
+    otherTransaction.seller = otherSeller;
+    otherTransaction.buyer = otherBuyer;
+
+    const matchingReview = TransactionReviewFactory.fake();
+    matchingReview.transaction = matchingTransaction;
+
+    const otherReview = TransactionReviewFactory.fake();
+    otherReview.transaction = otherTransaction;
+
+    await new DataFactory()
+      .createUsers(seller, buyer, otherSeller, otherBuyer)
+      .createTransactions(matchingTransaction, otherTransaction)
+      .createTransactionReviews(matchingReview, otherReview)
+      .write();
+
+    const response = await transactionReviewController.getTransactionReviews(
+      seller.firebaseUid,
+    );
+
+    expect(response.reviews).toHaveLength(1);
+    expect(response.reviews[0].transaction.seller.firebaseUid).toEqual(
+      seller.firebaseUid,
+    );
   });
 });

--- a/src/tests/UserReviewTest.test.ts
+++ b/src/tests/UserReviewTest.test.ts
@@ -55,6 +55,32 @@ describe('user review tests', () => {
     const response = await userReviewController.getUserReviews();
 
     expect(response.reviews).toHaveLength(1);
+    expect(response.reviews[0].seller).toBeDefined();
+  });
+
+  test("get user reviews filtered by sellerId", async () => {
+    const seller = UserFactory.fakeTemplate2();
+    const otherSeller = UserFactory.fake();
+    const buyer = UserFactory.fakeTemplate();
+    const otherBuyer = UserFactory.fake();
+
+    const matchingReview = UserReviewFactory.fake();
+    matchingReview.buyer = buyer;
+    matchingReview.seller = seller;
+
+    const nonMatchingReview = UserReviewFactory.fake();
+    nonMatchingReview.buyer = otherBuyer;
+    nonMatchingReview.seller = otherSeller;
+
+    await new DataFactory()
+      .createUsers(buyer, otherBuyer, seller, otherSeller)
+      .createUserReviews(matchingReview, nonMatchingReview)
+      .write();
+
+    const response = await userReviewController.getUserReviews(seller.firebaseUid);
+
+    expect(response.reviews).toHaveLength(1);
+    expect(response.reviews[0].seller.firebaseUid).toEqual(seller.firebaseUid);
   });
 
   test("get user review by id", async () => {


### PR DESCRIPTION
Currently when running the seller endpoint from the frontend, the backend doesn't seem to be filtering reviews by sellers, rather it returns all user reviews. This means filtering is left to the client (frontend), which seems like wasted work and bad practice.

Made-with: Cursor


## Overview / Changes

Changed review service to only search for reviews via seller id. Enforcing that a seller id is required when looking for reviews. 

## Test Coverage

Added relevant unit tests

## Related PRs or Issues 

(https://github.com/cuappdev/resell-ios/issues/96)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review endpoints now support optional seller ID filtering to display seller-specific transaction and user reviews.

* **Tests**
  * Added test coverage to verify seller ID filtering functionality works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->