### PR TITLE
Fix AuthorizationRefactor Firebase load in migrate CI

### DIFF
--- a/.github/workflows/migrate-neon.yml
+++ b/.github/workflows/migrate-neon.yml
@@ -55,4 +55,8 @@ jobs:
           echo "DATABASE_URL=$URL" >> "$GITHUB_ENV"
 
       - name: Run migrations
+        env:
+          # Needed only if AuthorizationRefactor (or similar) still has to run.
+          # Safe when unset if that migration is already recorded as applied.
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
         run: npm run db:migrate

--- a/src/migrations/1740628691583-AuthorizationRefactor.ts
+++ b/src/migrations/1740628691583-AuthorizationRefactor.ts
@@ -5,11 +5,36 @@ import {
 } from "../utils/AuthorizationRefactor";
 import * as admin from "firebase-admin";
 
-// Firebase Initialization
-const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH!;
-const serviceAccount = require(serviceAccountPath);
+/**
+ * Initialize Firebase only when this migration's `up` runs.
+ * TypeORM loads every migration module on `migration:run`; top-level
+ * `require(FIREBASE_SERVICE_ACCOUNT_PATH)` breaks CI when that env is unset.
+ */
+function ensureFirebaseApp(): void {
+  if (admin.apps.length) return;
 
-if (!admin.apps.length) {
+  const json = process.env.FIREBASE_SERVICE_ACCOUNT_JSON?.trim();
+  let serviceAccount: admin.ServiceAccount;
+
+  if (json) {
+    try {
+      serviceAccount = JSON.parse(json) as admin.ServiceAccount;
+    } catch {
+      const decoded = Buffer.from(json, "base64").toString("utf8");
+      serviceAccount = JSON.parse(decoded) as admin.ServiceAccount;
+    }
+  } else {
+    const serviceAccountPath = process.env.FIREBASE_SERVICE_ACCOUNT_PATH;
+    if (!serviceAccountPath) {
+      throw new Error(
+        "AuthorizationRefactor migration requires FIREBASE_SERVICE_ACCOUNT_JSON " +
+          "or FIREBASE_SERVICE_ACCOUNT_PATH when this migration still needs to run.",
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    serviceAccount = require(serviceAccountPath) as admin.ServiceAccount;
+  }
+
   admin.initializeApp({
     credential: admin.credential.cert(serviceAccount),
   });
@@ -17,6 +42,8 @@ if (!admin.apps.length) {
 
 export class AuthorizationRefactor1740628691583 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
+    ensureFirebaseApp();
+
     // Add new column as nullable initially
     await queryRunner.query(
       `ALTER TABLE "User" ADD COLUMN "firebaseUid" VARCHAR`,


### PR DESCRIPTION
## Summary
- Move Firebase admin init out of module scope in `AuthorizationRefactor` so `migration:run` can load the file without `FIREBASE_SERVICE_ACCOUNT_PATH`.
- Support `FIREBASE_SERVICE_ACCOUNT_JSON` (and base64 JSON) the same way as the app.
- Pass `secrets.FIREBASE_SERVICE_ACCOUNT_JSON` into the migrate workflow for cases where this migration still needs to run.

## Follow-up (if staging is a fresh Neon DB)
Add repo secret `FIREBASE_SERVICE_ACCOUNT_JSON` (same value as Vercel). If that migration is already applied on staging, migrate can succeed without it.

## Test plan
- [ ] Merge to `main`
- [ ] Confirm Migrate Neon database succeeds (or only fails with a clear missing-Firebase error if AuthorizationRefactor is still pending and the secret is absent)
- [ ] Re-run workflow after adding the secret if needed


Made with [Cursor](https://cursor.com)